### PR TITLE
Adding data observability

### DIFF
--- a/text/roadmap.md
+++ b/text/roadmap.md
@@ -129,10 +129,13 @@
 
 *Note: Cloud Composer is a managed Apache Airflow service on Google Cloud Platform.*
 
-* Monitoring data pipelines
+* Monitoring and observability for data pipelines
 	* Prometheus [general recommendation]
 	* Datadog [general recommendation]
 	* Sentry [general recommendation]
+	* Monte Carlo
+	* Datafold
+	* Soda Data
 	* StatsD
 
 * Networking


### PR DESCRIPTION
Adding "data observability" as part of "monitoring" section for modern data engineering stack; listed solutions in the space.

Someone will need to update the image accordingly.